### PR TITLE
Feat: add language support (pt/en) and contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,179 @@
+# 🌍 Contributing to GitHub Readme Educational Badge
+
+Thank you for your interest in contributing to this project! We especially welcome contributions for **new language translations**.
+
+## 🗣️ Adding a New Language Translation
+
+### Step 1: Check if your language is already supported
+
+Currently supported languages:
+- 🇺🇸 **English** (`en`)
+- 🇧🇷 **Portuguese** (`pt`)
+
+If your language is not listed, follow the steps below to add it!
+
+### Step 2: Fork and Clone
+
+1. Fork this repository on GitHub
+2. Clone your fork locally:
+```bash
+git clone https://github.com/Glauedson/github-readme-educational-badge.git
+cd github-readme-educational-badge
+```
+
+### Step 3: Add Your Translation
+
+Navigate to the translations file: `src/translations/translations.js`
+
+Add your language translation following this structure:
+
+```javascript
+export const translations = {
+  // Add your language here (replace 'xx' with your language code)
+  xx: {
+    course: "YOUR_TRANSLATION_FOR_COURSE",
+    institution: "YOUR_TRANSLATION_FOR_INSTITUTION",
+    completion: "YOUR_TRANSLATION_FOR_COMPLETION:",
+    institutionLogo: "YOUR_TRANSLATION_FOR_INSTITUTION_LOGO",
+    errors: {
+      invalidParameters: "YOUR_TRANSLATION_FOR_INVALID_PARAMETERS",
+      invalidProgress: "YOUR_TRANSLATION_FOR_INVALID_PROGRESS_MESSAGE",
+      internalError: "YOUR_TRANSLATION_FOR_INTERNAL_ERROR",
+      nameRequired: "YOUR_TRANSLATION_FOR_NAME_REQUIRED",
+      courseRequired: "YOUR_TRANSLATION_FOR_COURSE_REQUIRED",
+      degreeRequired: "YOUR_TRANSLATION_FOR_DEGREE_REQUIRED",
+      progressRequired: "YOUR_TRANSLATION_FOR_PROGRESS_REQUIRED"
+    }
+  }
+};
+```
+
+### Step 4: Language Code Guidelines
+
+Use the standard **ISO 639-1** language codes:
+
+| Language | Code | Flag |
+|----------|------|------|
+| Spanish | `es` | 🇪🇸 |
+| French | `fr` | 🇫🇷 |
+| German | `de` | 🇩🇪 |
+| Italian | `it` | 🇮🇹 |
+| Japanese | `ja` | 🇯🇵 |
+| Korean | `ko` | 🇰🇷 |
+| Chinese (Simplified) | `zh` | 🇨🇳 |
+| Russian | `ru` | 🇷🇺 |
+
+### Step 5: Translation Example
+
+Here's an example for English (`en`):
+
+```javascript
+en: {
+    course: "COURSE",
+    institution: "INSTITUTION",
+    completion: "COMPLETION:", 
+    institutionLogo: "Institution Logo",
+    errors: {
+      invalidParameters: "Invalid parameters",
+      invalidProgress: "Progress must be a number between 0 and 100",
+      internalError: "Internal server error generating badge", 
+      nameRequired: "name is required",
+      courseRequired: "course is required",
+      degreeRequired: "degree is required", 
+      progressRequired: "progress is required"
+    }
+}
+```
+
+### Step 6: Test Your Translation
+
+1. Install dependencies:
+```bash
+npm install
+```
+
+2. Start the development server:
+```bash
+npm run dev
+```
+
+3. Test your translation by visiting:
+```
+http://localhost:3000/XX/badge?name=Test&course=Test&degree=Test&progress=50
+```
+Replace `XX` with your language code.
+
+### Step 7: Update Documentation
+
+Add your language to the README.md:
+
+1. Update the "Supported Languages" table
+2. Add an example badge in your language
+
+### Step 8: Submit Your Pull Request
+
+1. Create a new branch:
+```bash
+git checkout -b add-language-XX
+```
+
+2. Commit your changes:
+```bash
+git add .
+git commit -m "Add XX (Language Name) translation support"
+```
+
+3. Push to your fork:
+```bash
+git push origin add-language-XX
+```
+
+4. Open a Pull Request on GitHub with:
+   - **Title:** `Add [Language Name] (xx) translation support`
+   - **Description:** Brief description of the language added and any notes
+
+## 📋 Translation Guidelines
+
+### ✅ Do:
+- Keep translations **concise** and **professional**
+- Use **UPPERCASE** for labels like "COURSE", "INSTITUTION" 
+- Add colon (`:`) after "COMPLETION" equivalent
+- Test your translation thoroughly
+- Follow the exact same structure as existing translations
+
+### ❌ Don't:
+- Don't change the structure of the translations object
+- Don't use informal language
+- Don't forget to translate error messages
+- Don't use language codes that are not ISO 639-1 standard
+
+## 🐛 Other Types of Contributions
+
+### Bug Reports
+- Use the GitHub Issues tab
+- Provide clear steps to reproduce
+- Include browser/environment information
+
+### Feature Requests
+- Check existing issues first
+- Clearly describe the feature
+- Explain the use case
+
+### Code Improvements
+- Follow the existing code style
+- Add comments for complex logic
+- Test your changes thoroughly
+
+## 🏆 Contributors
+
+All translation contributors will be credited in the README! Thank you for helping make this project accessible worldwide.
+
+## 📞 Need Help?
+
+- Open an issue on GitHub
+- Check existing issues and discussions
+- Review the project documentation
+
+---
+
+**Happy Contributing! 🚀**

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 <div align="center">
 
 <img src="https://cdn-icons-png.freepik.com/512/7500/7500948.png" width=100>
@@ -8,41 +7,115 @@
 Show your **current education** in your GitHub profile README!  
 Display your **university/college**, **course**, **degree type**, **progress percentage**, and even the **institution image/logo**.  
 
-</div>
+**🌍 Now with multi-language support!** Available in Portuguese and English, with more languages coming soon.
 
+</div>
 
 ## 🚀 Quick Setup  
 
 1. Copy-paste the markdown snippet below into your GitHub profile README.  
 2. Replace the query parameters with your own information:  
 
+### English Badge:
 ```md
-![badge](https://github-readme-educational-badge.vercel.app/badge?name=Harvard%20University&course=Computer%20Science&degree=Master&progress=90%25&img=https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQ9GQ7Ku6uEiT0B0nzcP1fqZT4XoDQiir4PRw&s)
+[![badge](https://github-readme-educational-badge.vercel.app/en/badge?name=Harvard%20University&course=Computer%20Science&degree=Master&progress=90%25&img=https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQ9GQ7Ku6uEiT0B0nzcP1fqZT4XoDQiir4PRw&s)](https://github.com/Glauedson/github-readme-educational-badge)
+```
+
+### Portuguese Badge:
+```md
+[![badge](https://github-readme-educational-badge.vercel.app/pt/badge?name=Harvard%20University&course=Ciência%20da%20Computação&degree=Mestrado&progress=90%25&img=https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQ9GQ7Ku6uEiT0B0nzcP1fqZT4XoDQiir4PRw&s)](https://github.com/Glauedson/github-readme-educational-badge)
 ```
 
 <div align=center>
 
-### Response:
+### Response Examples:
 
-![badge](https://github-readme-educational-badge.vercel.app/badge?name=Harvard%20University&course=Computer%20Science&degree=Master&progress=90%25&img=https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQ9GQ7Ku6uEiT0B0nzcP1fqZT4XoDQiir4PRw&s)
+**English:**
+![badge](https://github-readme-educational-badge.vercel.app/en/badge?name=Harvard%20University&course=Computer%20Science&degree=Master&progress=90%25&img=https://www.designyourway.net/blog/wp-content/uploads/2024/04/harvard-logo.jpg)
+
+**Portuguese:**
+![badge](https://github-readme-educational-badge.vercel.app/pt/badge?name=Harvard%20University&course=Ciência%20da%20Computação&degree=Mestrado&progress=90%25&img=https://www.designyourway.net/blog/wp-content/uploads/2024/04/harvard-logo.jpg)
+
 </div>
 
 3. Star the repo :)
 
+## 🌍 Supported Languages
+
+| Language | Code | Example URL |
+|----------|------|-------------|
+| English  | `en` | `/en/badge?name=...` |
+| Portuguese | `pt` | `/pt/badge?name=...` |
+
+> [!NOTE]
+>
+> If no language is specified, English will be used by default. Example: `/badge?name=...` = `/en/badge?name=...`
+
 ## 🔑 Parameters  
 
-| Parameter   | Description |
-|-------------|-------------|
-| `name`      | Institution name ( e.g., *Harvad* ) |
-| `course`    | Course/Program ( e.g., *software engineering* ) |
-| `degree`    | Degree type ( e.g., *Bachelor*, *Master*, *PhD* ) |
-| `progress`  | Percentage of completion ( e.g., *85%25* ) |
-| `img`       | Link to institution logo or image |
+| Parameter   | Description | Required |
+|-------------|-------------|----------|
+| `name`      | Institution name ( e.g., *Harvard University* ) | ✅ |
+| `course`    | Course/Program ( e.g., *Computer Science* ) | ✅ |
+| `degree`    | Degree type ( e.g., *Bachelor*, *Master*, *PhD* ) | ✅ |
+| `progress`  | Percentage of completion ( e.g., *85* - without % symbol ) | ✅ |
+| `img`       | Link to institution logo or image | ❌ |
+
+## 📝 API Endpoints
+
+### Get Badge
+```
+GET /{language}/badge
+GET /badge  # defaults to English
+```
+
+**Query Parameters:** All parameters listed in the table above.
+
+### Get API Info
+```
+GET /
+```
+
+Returns information about supported languages and example usage.
+
+## 🌐 Contributing to Translations
+
+We welcome contributions for new language translations! Currently supported:
+- 🇺🇸 English (en)
+- 🇧🇷 Portuguese (pt)
+
+**Want to add your language?** Check out our [CONTRIBUTING.md](CONTRIBUTING.md) guide for detailed instructions on how to add translations.
 
 ## ⭐ Contribute
 - Star the repo if you like it!
 - Open an issue for bugs or feature requests.
 - Pull requests are welcome to improve the badge design or add new features.
+- Help us translate the badge to more languages! See [CONTRIBUTING.md](CONTRIBUTING.md)
 
-<!--- ![badge](https://github-readme-educational-badge.vercel.app/badge?name=Instituto%20Federal%20do%20Ceará&course=Análise%20e%20Desenvolvimento%20de%20Sis.&degree=Bachelor&progress=85%25&img=https://ifce.edu.br/noticias/noticias-de-destaque/ifce-jaguaruana-oferta-1a-graduacao-gratuita-da-cidade/img-20230613-wa0041-fotor-20230614135142.jpg/@@images/2561275b-47b5-44b8-9e6c-e91a732acd6a.jpeg)
+## 🔧 Development
+
+```bash
+# Clone the repository
+git clone https://github.com/your-username/github-readme-educational-badge.git
+
+# Install dependencies
+npm install
+
+# Start development server
+npm run dev
+```
+
+## 📄 License
+
+This project is licensed under the MIT License.
+
+## 📩 Contato
+
+For any questions or suggestions, feel free to reach out:
+
+- **Name**: Glauedson Carlos Rodrigues
+- **Email**: [glauedson18s@gmail.com](glauedson18s@gmail.com)
+- **LinkedIn**: [Glauedson Carlos](https://www.linkedin.com/in/glauedson-carlos-89875b258)
+
+<!--- ![badge](https://github-readme-educational-badge.vercel.app/pt/badge?name=Instituto%20Federal%20do%20Ceará&course=Análise%20e%20Desenvolvimento%20de%20Sis.&degree=Tecnólogo&progress=85%25&img=https://ifce.edu.br/noticias/noticias-de-destaque/ifce-jaguaruana-oferta-1a-graduacao-gratuita-da-cidade/img-20230613-wa0041-fotor-20230614135142.jpg/@@images/2561275b-47b5-44b8-9e6c-e91a732acd6a.jpeg)
 -->

--- a/src/app.js
+++ b/src/app.js
@@ -4,12 +4,10 @@ import { startCacheCleanup } from "./utils/image.utils.js";
 
 const app = express();
 
+// Start image cache cleanup
 startCacheCleanup();
 
-app.get("/", (req, res) => {
-  res.send("Academic Badge API is running! 🎓");
-});
-
+// Use badge routes (includes language routing)
 app.use("/", badgeRoutes);
 
 export default app;

--- a/src/controllers/badge.controller.js
+++ b/src/controllers/badge.controller.js
@@ -1,43 +1,64 @@
 import { generateBadge } from "../services/badge.service.js";
 import { validateBadgeParams, validateProgress } from "../utils/validation.utils.js";
+import { getTranslation, isValidLanguage, getDefaultLanguage } from "../utils/i18n.utils.js";
 
 export async function getBadge(req, res) {
   try {
-    const { name, course, degree, progress, img } = req.query;
+    // Extract language from params (from route like /:lang/badge)
+    const language = req.params.lang || getDefaultLanguage();
     
-    const validationErrors = validateBadgeParams({ name, course, degree, progress });
-    if (validationErrors.length > 0) {
+    // Validate language
+    if (!isValidLanguage(language)) {
       return res.status(400).json({
-        error: `Parâmetros inválidos: ${validationErrors.join(', ')}`,
-        example: "/badge?name=UNIFOR&course=Ciência da Computação&degree=Bacharelado&progress=75&img=https://exemplo.com/logo.png"
+        error: getTranslation(getDefaultLanguage(), 'errors.invalidParameters'),
+        message: `Unsupported language: ${language}. Supported languages: pt, en`
       });
     }
 
-    const progressValidation = validateProgress(progress);
+    const { name, course, degree, progress, img } = req.query;
+    
+    // Validate badge parameters with localized error messages
+    const validationErrors = validateBadgeParams({ name, course, degree, progress }, language);
+    if (validationErrors.length > 0) {
+      return res.status(400).json({
+        error: `${getTranslation(language, 'errors.invalidParameters')}: ${validationErrors.join(', ')}`,
+        example: `/${language}/badge?name=UNIFOR&course=Computer Science&degree=Bachelor&progress=75&img=https://example.com/logo.png`
+      });
+    }
+
+    // Validate progress with localized error message
+    const progressValidation = validateProgress(progress, language);
     if (!progressValidation.isValid) {
       return res.status(400).json({
         error: progressValidation.error
       });
     }
 
-    const svg = await generateBadge({ 
-      name, 
-      course, 
-      degree, 
-      progress: progressValidation.value, 
-      img: img || null 
+    // Generate badge with language context
+    const svg = await generateBadge({
+      name,
+      course,
+      degree,
+      progress: progressValidation.value,
+      img: img || null,
+      language 
     });
 
+    // Set response headers
     res.setHeader("Content-Type", "image/svg+xml");
     res.setHeader("Cache-Control", "public, max-age=300");
     res.setHeader("Access-Control-Allow-Origin", "*");
-    
+    res.setHeader("Content-Language", language);
     res.send(svg);
-    
+
   } catch (error) {
     console.error("Error generating badge:", error);
+    const errorLanguage = req.params.lang && isValidLanguage(req.params.lang) 
+      ? req.params.lang 
+      : getDefaultLanguage();
+    
     res.status(500).json({
-      error: "Internal server error generating badge"
+      error: getTranslation(errorLanguage, 'errors.internalError')
     });
   }
 }

--- a/src/routes/badge.routes.js
+++ b/src/routes/badge.routes.js
@@ -1,8 +1,29 @@
 import { Router } from "express";
 import { getBadge } from "../controllers/badge.controller.js";
+import { getSupportedLanguages, getDefaultLanguage } from "../utils/i18n.utils.js";
 
 const router = Router();
 
-router.get("/badge", getBadge);
+// Route with language parameter (e.g., /pt/badge, /en/badge)
+router.get("/:lang/badge", getBadge);
+
+// Default route without language (uses default language)
+router.get("/badge", (req, res, next) => {
+  req.params.lang = getDefaultLanguage();
+  next();
+}, getBadge);
+
+// Health check route with supported languages info
+router.get("/", (req, res) => {
+  res.json({
+    message: "Academic Badge API is running! 🎓",
+    supportedLanguages: getSupportedLanguages(),
+    defaultLanguage: getDefaultLanguage(),
+    examples: {
+      portuguese: "/pt/badge?name=UNIFOR&course=Ciência da Computação&degree=Bacharelado&progress=75",
+      english: "/en/badge?name=UNIFOR&course=Computer Science&degree=Bachelor&progress=75"
+    }
+  });
+});
 
 export default router;

--- a/src/services/badge.service.js
+++ b/src/services/badge.service.js
@@ -1,11 +1,17 @@
 import { badgeSvg } from "../templates/badge.svg.js";
 import { fetchImageAsBase64 } from "../utils/image.utils.js";
+import { getDefaultLanguage } from "../utils/i18n.utils.js";
 
 export async function generateBadge(data) {
+  // Fetch image data if URL is provided
   const imageData = data.img ? await fetchImageAsBase64(data.img) : null;
-
+  
+  // Ensure language is set, fallback to default if not provided
+  const language = data.language || getDefaultLanguage();
+  
   return badgeSvg({
     ...data,
-    img: imageData
+    img: imageData,
+    language
   });
 }

--- a/src/templates/badge.svg.js
+++ b/src/templates/badge.svg.js
@@ -1,32 +1,28 @@
-import { 
-  createImageSection, 
-  createBadgeHeader, 
-  createMainContent, 
+import {
+  createImageSection,
+  createBadgeHeader,
+  createMainContent,
   createProgressBar,
   getSvgDefs,
   getSvgStyles
 } from "../utils/svg.utils.js";
 
-export function badgeSvg({ name, course, degree, progress, img }) {
+export function badgeSvg({ name, course, degree, progress, img, language }) {
   return `
     <svg xmlns="http://www.w3.org/2000/svg" width="410" height="173">
-      ${getSvgStyles()}
-      ${getSvgDefs()}
-      
-      <!-- Background card -->
-      <rect x="0" y="0" width="400" height="160" rx="8" ry="8" fill="#ffffffff" filter="url(#shadow)"/>
-      
-      <!-- Badge degree -->
-      ${createBadgeHeader(degree)}
-      
-      <!-- img or placeholder -->
-      ${createImageSection(img, name)}
-      
-      <!-- Info user -->
-      ${createMainContent(course, name)}
-      
-      <!-- Progress bar -->
-      ${createProgressBar(progress)}
+    ${getSvgStyles()}
+    ${getSvgDefs()}
+    <!-- Background card -->
+    <rect x="0" y="0" width="400" height="160" rx="8" ry="8"
+    fill="#ffffffff" filter="url(#shadow)"/>
+    <!-- Badge degree -->
+    ${createBadgeHeader(degree)}
+    <!-- Image or placeholder -->
+    ${createImageSection(img, name, language)}
+    <!-- User info -->
+    ${createMainContent(course, name, language)}
+    <!-- Progress bar -->
+    ${createProgressBar(progress, language)}
     </svg>
   `;
 }

--- a/src/translations/translations.js
+++ b/src/translations/translations.js
@@ -1,0 +1,33 @@
+export const translations = {
+  pt: {
+    course: "CURSO",
+    institution: "INSTITUIÇÃO", 
+    completion: "CONCLUSÃO:",
+    institutionLogo: "Logo da Instituição",
+    errors: {
+      invalidParameters: "Parâmetros inválidos",
+      invalidProgress: "O progresso deve ser um número entre 0 e 100",
+      internalError: "Erro interno do servidor ao gerar badge",
+      nameRequired: "nome é obrigatório",
+      courseRequired: "curso é obrigatório", 
+      degreeRequired: "grau é obrigatório",
+      progressRequired: "progresso é obrigatório"
+    }
+  },
+  en: {
+    course: "COURSE",
+    institution: "INSTITUTION",
+    completion: "COMPLETION:", 
+    institutionLogo: "Institution Logo",
+    errors: {
+      invalidParameters: "Invalid parameters",
+      invalidProgress: "Progress must be a number between 0 and 100",
+      internalError: "Internal server error generating badge", 
+      nameRequired: "name is required",
+      courseRequired: "course is required",
+      degreeRequired: "degree is required", 
+      progressRequired: "progress is required"
+    }
+  }
+  
+};

--- a/src/utils/i18n.utils.js
+++ b/src/utils/i18n.utils.js
@@ -1,0 +1,40 @@
+import { translations } from "../translations/translations.js";
+
+// Default language
+const DEFAULT_LANGUAGE = 'en';
+
+// Get supported languages dynamically from translations
+const SUPPORTED_LANGUAGES = Object.keys(translations);
+
+export function getTranslation(language, key) {
+  // Validate language
+  if (!SUPPORTED_LANGUAGES.includes(language)) {
+    language = DEFAULT_LANGUAGE;
+  }
+
+  // Get nested translation using dot notation
+  const keys = key.split('.');
+  let translation = translations[language];
+  
+  for (const k of keys) {
+    if (translation && typeof translation === 'object') {
+      translation = translation[k];
+    } else {
+      return key; 
+    }
+  }
+  
+  return translation || key;
+}
+
+export function isValidLanguage(language) {
+  return SUPPORTED_LANGUAGES.includes(language);
+}
+
+export function getDefaultLanguage() {
+  return DEFAULT_LANGUAGE;
+}
+
+export function getSupportedLanguages() {
+  return [...SUPPORTED_LANGUAGES];
+}

--- a/src/utils/svg.utils.js
+++ b/src/utils/svg.utils.js
@@ -1,6 +1,7 @@
 import { sanitizeText } from './validation.utils.js';
+import { getTranslation, getDefaultLanguage } from './i18n.utils.js';
 
-export function createImageSection(img, name) {
+export function createImageSection(img, name, language = getDefaultLanguage()) {
   if (img) {
     return `
       <defs>
@@ -9,91 +10,113 @@ export function createImageSection(img, name) {
         </clipPath>
       </defs>
       <image
-        href="${img}"
-        x="0" y="15"
-        width="145" height="145"
-        preserveAspectRatio="xMidYMid slice"
-        clip-path="url(#imageClip)"
+      href="${img}"
+      x="0" y="15"
+      width="145" height="145"
+      preserveAspectRatio="xMidYMid slice"
+      clip-path="url(#imageClip)"
       />
     `;
   }
 
-  return createPlaceholder(name);
+  return createPlaceholder(name, language);
 }
 
-function createPlaceholder(name) {
+function createPlaceholder(name, language = getDefaultLanguage()) {
   const displayName = sanitizeText(name, 15);
+  const institutionLogoText = getTranslation(language, 'institutionLogo');
   
   return `
-    <rect x="0" y="15" width="145" height="145" fill="#f8f9fa" stroke="#e9ecef" stroke-width="2" rx="4" ry="4"/>
+    <rect x="0" y="15" width="145" height="145" fill="#f8f9fa"
+    stroke="#e9ecef" stroke-width="2" rx="4" ry="4"/>
+
     <circle cx="72.5" cy="65" r="25" fill="#dee2e6"/>
-    <text x="72.5" y="72" font-size="24" fill="#6c757d" text-anchor="middle">🎓</text>
-    <text x="72.5" y="95" font-size="12" fill="#6c757d" text-anchor="middle" font-weight="500">
+    <text x="72.5" y="72" font-size="24" fill="#6c757d"
+    text-anchor="middle">🎓</text>
+
+    <text x="72.5" y="95" font-size="12" fill="#6c757d"
+    text-anchor="middle" font-weight="500">
       ${displayName}
     </text>
-    <text x="72.5" y="110" font-size="10" fill="#868e96" text-anchor="middle">
-      Logo da Instituição
+
+    <text x="72.5" y="110" font-size="10" fill="#868e96"
+    text-anchor="middle">
+      ${institutionLogoText}
     </text>
   `;
 }
 
 export function createBadgeHeader(degree) {
   return `
-    <rect x="270" y="0" width="140" height="35" rx="15" ry="15" fill="#D5D5D5"/>
-    <svg x="285" y="8" width="20" height="20" viewBox="0 0 24 24" fill="none">
-      <path d="M12 3L1 9L12 15L21 12.09V17H23V9L12 3Z" fill="#000000ff"/>
-      <path d="M5 13.18V17.18C5 19.45 8.58 21 12 21C15.42 21 19 19.45 19 17.18V13.18L12 15.91L5 13.18Z" fill="#000000ff"/>
+    <rect x="270" y="0" width="140" height="35" rx="15" ry="15"
+    fill="#D5D5D5"/>
+
+    <svg x="285" y="8" width="20" height="20" viewBox="0 0 24 24"
+    fill="none">
+      <path d="M12 3L1 9L12 15L21 12.09V17H23V9L12 3Z"
+      fill="#000000ff"/>
+      <path d="M5 13.18V17.18C5 19.45 8.58 21 12 21C15.42 21 19 19.45
+      19 17.18V13.18L12 15.91L5 13.18Z" fill="#000000ff"/>
     </svg>
-    <text x="320" y="22" font-size="12" font-weight="600" fill="#000000ff">
+
+    <text x="320" y="22" font-size="12" font-weight="600"
+    fill="#000000ff">
       ${degree}
     </text>
   `;
 }
 
-export function createMainContent(course, name) {
+export function createMainContent(course, name, language = getDefaultLanguage()) {
   const displayCourse = sanitizeText(course, 25);
   const displayName = sanitizeText(name, 25);
-  
+  const courseLabel = getTranslation(language, 'course');
+  const institutionLabel = getTranslation(language, 'institution');
+
   return `
-    <text x="160" y="40" font-size="10" font-weight="500" fill="#666666" letter-spacing="1px">
-      CURSO
+    <text x="160" y="40" font-size="10" font-weight="500"
+    fill="#666666" letter-spacing="1px">
+    ${courseLabel}
     </text>
-    <text x="160" y="57" font-size="14" font-weight="600" fill="#000000">
-      ${displayCourse}
+    <text x="160" y="57" font-size="14" font-weight="600"
+    fill="#000000">
+    ${displayCourse}
     </text>
-    
-    <text x="160" y="78" font-size="10" font-weight="500" fill="#666666" letter-spacing="1px">
-      INSTITUIÇÃO
+    <text x="160" y="78" font-size="10" font-weight="500"
+    fill="#666666" letter-spacing="1px">
+    ${institutionLabel}
     </text>
-    <text x="160" y="95" font-size="14" font-weight="600" fill="#000000">
-      ${displayName}
+    <text x="160" y="95" font-size="14" font-weight="600"
+    fill="#000000">
+    ${displayName}
     </text>
   `;
 }
 
-export function createProgressBar(progress) {
+export function createProgressBar(progress, language = getDefaultLanguage()) {
   const progressWidth = Math.max((progress / 100) * 215, 0);
-  
+  const completionLabel = getTranslation(language, 'completion');
+
   return `
-    <text x="160" y="125" font-size="10" font-weight="500" fill="#666666">
-      CONCLUSÃO:
+    <text x="160" y="125" font-size="10" font-weight="500"
+      fill="#666666">
+      ${completionLabel}
     </text>
-    <text x="375" y="125" font-size="12" font-weight="bold" fill="#4CAF50" text-anchor="end">
+    <text x="375" y="125" font-size="12" font-weight="bold"
+    fill="#4CAF50" text-anchor="end">
       ${progress}%
     </text>
-    
     <!-- Progress bar (background) -->
-    <rect x="160" y="135" width="215" height="6" fill="#e0e0e0" rx="3" ry="3" />
-    
+    <rect x="160" y="135" width="215" height="6" fill="#e0e0e0" rx="3"
+    ry="3" />
     <!-- Progress bar (filling) -->
-    <rect 
-      x="160" 
-      y="135" 
-      width="${progressWidth}" 
-      height="6" 
-      fill="url(#progressGradient)" 
-      rx="3" 
-      ry="3" 
+    <rect
+    x="160"
+    y="135"
+    width="${progressWidth}"
+    height="6"
+    fill="url(#progressGradient)"
+    rx="3"
+    ry="3"
     />
   `;
 }
@@ -102,11 +125,13 @@ export function getSvgDefs() {
   return `
     <defs>
       <filter id="shadow" x="0" y="0.1" width="100%" height="100%">
-        <feDropShadow dx="0" dy="0" stdDeviation="6" flood-color="rgba(3, 3, 3, 0.18)" />
+        <feDropShadow dx="0" dy="0" stdDeviation="6"
+        flood-color="rgba(3, 3, 3, 0.18)" />
       </filter>
-      <linearGradient id="progressGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-        <stop offset="0%" style="stop-color:#4CAF50;stop-opacity:1" />
-        <stop offset="100%" style="stop-color:#8BC34A;stop-opacity:1" />
+      <linearGradient id="progressGradient" x1="0%" y1="0%" x2="100%"
+      y2="0%">
+      <stop offset="0%" style="stop-color:#4CAF50;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#8BC34A;stop-opacity:1"/>
       </linearGradient>
     </defs>
   `;
@@ -115,9 +140,9 @@ export function getSvgDefs() {
 export function getSvgStyles() {
   return `
     <style>
-      text {
-        font-family: 'Poppins', sans-serif;
-      }
+    text {
+      font-family: 'Poppins', sans-serif;
+    }
     </style>
   `;
 }

--- a/src/utils/validation.utils.js
+++ b/src/utils/validation.utils.js
@@ -1,35 +1,34 @@
-export function validateBadgeParams({ name, course, degree, progress }) {
+import { getTranslation, getDefaultLanguage } from './i18n.utils.js';
+
+export function validateBadgeParams({ name, course, degree, progress }, language = getDefaultLanguage()) {
   const errors = [];
 
   if (!name?.trim()) {
-    errors.push('name is required');
+    errors.push(getTranslation(language, 'errors.nameRequired'));
   }
-
   if (!course?.trim()) {
-    errors.push('course is required');
+    errors.push(getTranslation(language, 'errors.courseRequired'));
   }
-
   if (!degree?.trim()) {
-    errors.push('degree is required');
+    errors.push(getTranslation(language, 'errors.degreeRequired'));
   }
-
   if (!progress) {
-    errors.push('progress is required');
+    errors.push(getTranslation(language, 'errors.progressRequired'));
   }
-
+  
   return errors;
 }
 
-export function validateProgress(progress) {
+export function validateProgress(progress, language = getDefaultLanguage()) {
   const progressNum = parseInt(progress);
   
   if (isNaN(progressNum) || progressNum < 0 || progressNum > 100) {
     return {
       isValid: false,
-      error: 'Progress must be a number between 0 and 100'
+      error: getTranslation(language, 'errors.invalidProgress')
     };
   }
-
+  
   return {
     isValid: true,
     value: progressNum
@@ -39,7 +38,7 @@ export function validateProgress(progress) {
 export function sanitizeText(text, maxLength = 25) {
   if (!text) return '';
   const cleaned = text.trim();
-  return cleaned.length > maxLength 
-    ? cleaned.substring(0, maxLength) + '...' 
+  return cleaned.length > maxLength
+    ? cleaned.substring(0, maxLength) + '...'
     : cleaned;
 }


### PR DESCRIPTION
## 🎯 Overview
This PR introduces multi-language support for the badge service and adds a contributing guide.

## ✨ Changes
- Added option to render the badge in **Portuguese (pt)** or **English (en)**
- Updated documentation with `CONTRIBUTING.md` to guide contributors
- Improved code modularity to handle future language additions

## 🚀 Benefits
- Developers can now choose between **/pt/** and **/en/** routes when generating a badge
- Clear contribution guidelines for external collaborators
- Foundation for supporting more languages in the future

## 🧪 Testing
- ✅ Badge correctly renders in Portuguese  
- ✅ Badge correctly renders in English  
- ✅ Documentation available and easy to follow  

---
